### PR TITLE
FLUID-5534: Updating so that the tests will pass after an npm install.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -526,7 +526,7 @@ module.exports = function (grunt) {
 
     });
 
-    grunt.registerTask("cleanForDist", ["clean:build", "clean:products", "clean:stylus", "clean:stylusDist", "clean:ciArtifacts"]);
+    grunt.registerTask("cleanForDist", ["clean:build", "clean:products", "clean:stylusDist", "clean:ciArtifacts"]);
     grunt.registerTask("buildStylus", ["clean:stylus", "stylus:compile"]);
 
     grunt.registerTask("default", ["build:all"]);

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "repository": "git://github.com/fluid-project/infusion.git",
     "main": "./src/module/fluid.js",
     "scripts": {
-        "prepublish": "grunt buildDists",
-        "test": "node tests/node-tests/basic-node-tests.js"
+        "prepublish": "npm run buildDists && npm run buildStylus",
+        "test": "node tests/node-tests/basic-node-tests.js",
+        "buildDists": "grunt buildDists",
+        "buildStylus": "grunt buildStylus"
     },
     "engines": {
         "node": ">=0.10.0"


### PR DESCRIPTION
Previously on install, stylus would not be compiled to CSS and on
buildDist any generated CSS would be removed. However the CSS is now
required for the responsive tests and must be in place.